### PR TITLE
[policycoreutils] Remove unnecessary libcgroup dependency. JB#57050

### DIFF
--- a/rpm/policycoreutils.spec
+++ b/rpm/policycoreutils.spec
@@ -211,7 +211,7 @@ an SELinux environment.
 %{?python_provide:%python_provide python3-policycoreutils}
 Summary: SELinux policy core python3 interfaces
 Requires:policycoreutils = %{version}-%{release}
-Requires:libsemanage-python3 >= %{libsemanagever} libselinux-python3 libcgroup
+Requires:libsemanage-python3 >= %{libsemanagever} libselinux-python3
 # no python3-audit-libs yet
 Requires:audit-libs-python3 >=  %{libauditver}
 Requires: checkpolicy


### PR DESCRIPTION
Introduced in the first commit copying Fedora .spec but currently
there's are roughly even no cgroup references in the whole repository
and Fedora doesn't have such dependency either. And a plain
Requires without Build was strange anyway.

@saukko @Thaodan @Tomin1 