### PR TITLE
Backport python module build fix

### DIFF
--- a/rpm/0001-Disable-build-isolation-for-sepolicy-python-module.patch
+++ b/rpm/0001-Disable-build-isolation-for-sepolicy-python-module.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cathy Hu <cahu@suse.de>
+Date: Mon, 16 Feb 2026 17:07:34 +0100
+Subject: [PATCH] Disable build isolation for sepolicy python module
+
+same justification as:
+https://github.com/SELinuxProject/selinux/commit/17a9372391ad2c9bf0e440391d6fd13cb8cfdaf3
+
+Used patch by Daniel Garcia <daniel.garcia@suse.com>:
+https://build.opensuse.org/requests/1333291
+
+Signed-off-by: Cathy Hu <cahu@suse.de>
+Acked-by: Stephen Smalley <stephen.smalley.work@gmail.com>
+---
+ python/sepolicy/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/python/sepolicy/Makefile b/python/sepolicy/Makefile
+index 1a26cfdce6ccbab149e3f78ff39d0943ba7859dd..ccb22fe7da75f0d861e199237963959db1987286 100644
+--- a/python/sepolicy/Makefile
++++ b/python/sepolicy/Makefile
+@@ -27,7 +27,7 @@ test:
+ 	@$(PYTHON) test_sepolicy.py -v
+ 
+ install:
+-	$(PYTHON) -m pip install --prefix=$(PREFIX) `test -n "$(DESTDIR)" && echo --root $(DESTDIR) --ignore-installed --no-deps` $(PYTHON_SETUP_ARGS) .
++	$(PYTHON) -m pip install --no-build-isolation --prefix=$(PREFIX) `test -n "$(DESTDIR)" && echo --root $(DESTDIR) --ignore-installed --no-deps` $(PYTHON_SETUP_ARGS) .
+ 	[ -d $(DESTDIR)$(BINDIR) ] || mkdir -p $(DESTDIR)$(BINDIR)
+ 	install -m 755 sepolicy.py $(DESTDIR)$(BINDIR)/sepolicy
+ 	(cd $(DESTDIR)$(BINDIR); ln -sf sepolicy sepolgen)

--- a/rpm/policycoreutils.spec
+++ b/rpm/policycoreutils.spec
@@ -33,12 +33,13 @@ Version: 3.7
 Release: 1
 License: GPLv2
 Source: %{name}-%{version}.tar.bz2
-URL:     https://github.com/SELinuxProject
+URL:     https://github.com/sailfishos/policycoreutils
 Source15: selinux-autorelabel
 Source16: selinux-autorelabel.service
 Source17: selinux-autorelabel-mark.service
 Source18: selinux-autorelabel.target
 Source19: selinux-autorelabel-generator.sh
+Patch1:   0001-Disable-build-isolation-for-sepolicy-python-module.patch
 Provides: /sbin/fixfiles
 Provides: /sbin/restorecon
 
@@ -221,7 +222,7 @@ by python 3 in an SELinux environment.
 %{python3_sitelib}/sepolicy/network.py*
 %{python3_sitelib}/sepolicy/transition.py*
 %{python3_sitelib}/sepolicy/sedbus.py*
-%{python3_sitelib}/sepolicy*.egg-info
+%{python3_sitelib}/sepolicy*-info
 %{python3_sitelib}/sepolicy/__pycache__
 
 %package devel


### PR DESCRIPTION
Needed after updating python-pip.
Use packaging URL in spec.